### PR TITLE
GulpでTypeScriptのコンパイルが落ちたら止まるように

### DIFF
--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -11,3 +11,19 @@ gulp.task('clean', done => {
     config.dir.work.server,
   ]).then(pathes => done())
 })
+
+gulp.task('clean:dist', done => {
+  del(config.dir.dist).then(pathes => done())
+})
+
+gulp.task('clean:release', done => {
+  del(config.dir.release).then(pathes => done())
+})
+
+gulp.task('clean:test', done => {
+  del(config.dir.test).then(pathes => done())
+})
+
+gulp.task('clean:server', done => {
+  del(config.dir.server).then(pathes => done())
+})

--- a/gulp/tasks/script.js
+++ b/gulp/tasks/script.js
@@ -1,5 +1,6 @@
 const gulp = require('gulp')
 const $ = require('gulp-load-plugins')()
+const del = require('del')
 const config = require('../config')
 
 const project = $.typescript.createProject('tsconfig.json', {
@@ -30,11 +31,12 @@ gulp.task('script:server:watch',  () => {
 })
 
 gulp.task('script:test', () => {
+  del.sync(config.dir.work.test) // for stop typescript compile error
   return build([config.src.script, config.src.test], config.dir.work.test)
 })
 gulp.task('script:test:watch', () => {
   $.watch([config.src.script, config.src.test], config.watch, () => {
-    // @todo incremental build of typescript is difficult
+    del.sync(config.dir.work.test) // for stop typescript compile error
     build([config.src.script, config.src.test], config.dir.work.test, true)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react",
     "sourceMap": true,
     "noImplicitAny": true,
+    "noEmitOnError": true,
     "moduleResolution": "node",
     "baseUrl": "./src",
     "experimentalDecorators": true


### PR DESCRIPTION
* tsconfig.jsonに`noEmitOnError: true`を追加
* テストコードコンパイル前に前回の中間コードを全消去

Closes #8 