### PR TITLE
継続的テストが頻繁に失敗する問題の修正

### DIFF
--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -21,9 +21,9 @@ gulp.task('clean:release', done => {
 })
 
 gulp.task('clean:test', done => {
-  del(config.dir.test).then(pathes => done())
+  del(config.dir.work.test).then(pathes => done())
 })
 
 gulp.task('clean:server', done => {
-  del(config.dir.server).then(pathes => done())
+  del(config.dir.work.server).then(pathes => done())
 })

--- a/gulp/tasks/script.js
+++ b/gulp/tasks/script.js
@@ -30,13 +30,7 @@ gulp.task('script:server:watch',  () => {
   })
 })
 
+// for test
 gulp.task('script:test', () => {
-  del.sync(config.dir.work.test) // for stop typescript compile error
   return build([config.src.script, config.src.test], config.dir.work.test)
-})
-gulp.task('script:test:watch', () => {
-  $.watch([config.src.script, config.src.test], config.watch, () => {
-    del.sync(config.dir.work.test) // for stop typescript compile error
-    build([config.src.script, config.src.test], config.dir.work.test, true)
-  })
 })

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,24 +1,41 @@
 const gulp = require('gulp')
 const $ = require('gulp-load-plugins')()
+const runSequence = require('run-sequence')
 const config = require('../config')
 
+const workTestFiles = `${config.dir.work.test}/**/*.spec.js`
+const checkFileExists = `ls ${workTestFiles}>/dev/null 2>&1`
 const envNodePath = `NODE_PATH=${config.dir.work.test}`
-const mochaCommand = `${envNodePath} mocha ${config.dir.work.test}/**/*.spec.js`
+const mochaCommand = `${envNodePath} mocha ${workTestFiles}`
 
-gulp.task('test', ['script:test'], () => {
-  gulp.start([
+gulp.task('test', () => {
+  return runSequence(
+    'clean:test',
+    'script:test',
     'test:shell:mocha'
-  ])
+  )
 })
-gulp.task('test:watch', ['script:test'], () => {
-  gulp.start([
-    'script:test:watch',
-    'test:shell:mocha:watch',
-  ])
+
+gulp.task('test:watch', () => {
+  const build = () =>runSequence(
+    'clean:test',
+    'script:test',
+    'test:shell:mocha:min'
+  )
+  build()
+  $.watch([config.src.script, config.src.test], config.watch, build)
 })
-gulp.task('test:shell:mocha', $.shell.task([
-  `${mochaCommand}`
-]))
-gulp.task('test:shell:mocha:watch', $.shell.task([
-  `${mochaCommand} --reporter min --watch`
-]))
+
+gulp.task('test:shell:mocha', $.shell.task(`
+  if ${checkFileExists}; then
+    ${mochaCommand}
+  else
+    false
+  fi
+`))
+
+gulp.task('test:shell:mocha:min', $.shell.task(`
+  if ${checkFileExists}; then
+    ${mochaCommand} --reporter min
+  fi
+`))

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -17,7 +17,7 @@ gulp.task('test', () => {
 })
 
 gulp.task('test:watch', () => {
-  const build = () =>runSequence(
+  const build = () => runSequence(
     'clean:test',
     'script:test',
     'test:shell:mocha:min'

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "mocha": "^2.4.5",
     "power-assert": "^1.3.1",
     "require-dir": "^0.3.0",
+    "run-sequence": "^1.1.5",
     "typescript": "^1.9.0-dev.20160311",
     "typings": "^0.7.1",
     "uglifyify": "^3.0.1"


### PR DESCRIPTION
ソースファイル監視 => コンパイル => 中間ファイル
中間ファイル監視 => テスト実行

みたいな感じで、ファイル監視を数珠つなぎしてたせい？