### PR TITLE
メッセージにアバター画像を乗っける

### DIFF
--- a/src/components/StreamNotification.tsx
+++ b/src/components/StreamNotification.tsx
@@ -28,11 +28,18 @@ export default class StreamNotification extends Component<Props, State> {
     style['transition'] = `left ${STREAM_TRANS_MSEC}ms linear`
     return (
       <div className="Message" style={style}>
-        <div className="Message__meta">
-          <span className="Message__meta__user">{letter.user}</span>
-          <span className="Message__meta__channel">{letter.channel}</span>
+        <div className="Message__image">
+          <img src={letter.user.image} />
         </div>
-        <span className="Message__label" ref="label">{letter.message}</span>
+        <div className="Message__main">
+          <div className="Message__main__meta">
+            <span className="Message__main__meta__user">{letter.user.name}</span>
+            <span className="Message__main__meta__channel">{letter.channel.name}</span>
+          </div>
+          <div className="Message__main__label" ref="label">
+            {letter.message.toDisplay()}
+          </div>
+        </div>
       </div>
     )
   }

--- a/src/constants/AppConst.ts
+++ b/src/constants/AppConst.ts
@@ -1,2 +1,3 @@
 export const BASE_URL = `file://${__dirname}/../index.html`
 export const STREAM_TRANS_MSEC = 10000
+export const NO_IMAGE_URL = 'http://dummyimage.com/100x100/eee/333&text=NoImage'

--- a/src/domains/Letter.ts
+++ b/src/domains/Letter.ts
@@ -21,15 +21,15 @@ export default class Letter {
     return this.param.uid.toString()
   }
 
-  get user(): string {
-    return this.param.user.name
+  get user(): User {
+    return this.param.user
   }
 
-  get channel(): string {
-    return this.param.channel.name
+  get channel(): Channel {
+    return this.param.channel
   }
 
-  get message(): string {
-    return this.param.message.toDisplay()
+  get message(): Message {
+    return this.param.message
   }
 }

--- a/src/domains/SlackObject.ts
+++ b/src/domains/SlackObject.ts
@@ -1,6 +1,15 @@
 export interface UserObject {
   id: string
   name: string
+  profile: {
+    email: string,
+    image_24: string,
+    image_32: string,
+    image_48: string,
+    image_72: string,
+    image_192: string,
+    image_512: string,
+  }
 }
 
 export interface UserListObject {

--- a/src/domains/User.ts
+++ b/src/domains/User.ts
@@ -1,10 +1,12 @@
 import freeze from '../decorators/freeze'
+import {NO_IMAGE_URL} from '../constants/AppConst'
 
 @freeze
 export default class User {
   constructor(private param: {
     id: string
     name: string,
+    image?: string,
   }) {}
 
   get id(): string {
@@ -13,5 +15,9 @@ export default class User {
 
   get name(): string {
     return this.param.name
+  }
+
+  get image(): string {
+    return this.param.image || NO_IMAGE_URL
   }
 }

--- a/src/styles/components/Message.styl
+++ b/src/styles/components/Message.styl
@@ -1,4 +1,7 @@
 .Message
+  display flex
+  flex-direction row
+  align-items center
   position absolute
   top 0
   left 0
@@ -6,28 +9,45 @@
   // rewrite js
   //transition left 10s linear
 
-  &__meta
-    color #fff
-    margin-bottom -0.5em
-    text-shadow 1px 1px 1px #000,
-      -1px 1px 1px #000,
-      1px -1px 1px #000,
-      -1px -1px 1px #000
-    &__user
-      margin-right 1em
-      &:before
-        color #f33
-        content '@'
-    &__channel
-      &:before
-        color #3f3
-        content '#'
+  &__image
+    margin-right 10px
 
-  &__label
-    font-size 2em
-    font-weight bold
-    color white
-    text-shadow 2px 2px 1px #000,
-      -2px 2px 1px #000,
-      2px -2px 1px #000,
-      -2px -2px 1px #000
+    img
+      width 50px
+      height 50px
+      box-shadow 1px 1px 0px rgba(0,0,0,0.2),
+        -1px 1px 0px rgba(0,0,0,0.2),
+        1px -1px 0px rgba(0,0,0,0.2),
+        -1px -1px 0px rgba(0,0,0,0.2)
+      border-radius 100px
+
+  &__main
+
+    &__meta
+      color #fff
+      font-size 1.15em
+      margin-bottom -0.02em
+      text-shadow 1px 1px 1px #000,
+        -1px 1px 1px #000,
+        1px -1px 1px #000,
+        -1px -1px 1px #000
+      &__user
+        margin-right 1em
+        &:before
+          color #f33
+          content '@'
+      &__channel
+        &:before
+          color #3f3
+          content '#'
+
+    &__label
+      font-size 1.9em
+      font-weight bold
+      line-height 1
+      margin-bottom 5px
+      color white
+      text-shadow 2px 2px 1px #000,
+        -2px 2px 1px #000,
+        2px -2px 1px #000,
+        -2px -2px 1px #000

--- a/test/domains/Letter.spec.ts
+++ b/test/domains/Letter.spec.ts
@@ -7,17 +7,20 @@ import * as assert from 'power-assert'
 describe('Letter', function() {
 
   let letter: Letter
+  let user: User
+  let channel: Channel
+  let message: Message
 
   before(() => {
-    const user = new User({
+    user = new User({
       id: 'ID',
       name: 'User',
     })
-    const channel = new Channel({
+    channel = new Channel({
       id: 'ID',
       name: 'Channel',
     })
-    const message = new Message('Text')
+    message = new Message('Text')
     letter = new Letter({
       user, channel, message,
     })
@@ -37,19 +40,19 @@ describe('Letter', function() {
 
   describe('user', () => {
     it('should be return initial value', () => {
-      assert(letter.user === 'User')
+      assert(letter.user === user)
     })
   })
 
   describe('channel', () => {
     it('should be return initial value', () => {
-      assert(letter.channel === 'Channel')
+      assert(letter.channel === channel)
     })
   })
 
   describe('message', () => {
     it('should be return initial value', () => {
-      assert(letter.message === 'Text')
+      assert(letter.message === message)
     })
   })
 

--- a/test/domains/User.spec.ts
+++ b/test/domains/User.spec.ts
@@ -1,12 +1,19 @@
 import User from 'domains/User'
+import {NO_IMAGE_URL} from 'constants/AppConst'
 import * as assert from 'power-assert'
 
 describe('User', function() {
 
   let user: User
+  let userNoImage: User
 
   before(() => {
     user = new User({
+      id: 'ID',
+      name: 'Name',
+      image: 'Image',
+    })
+    userNoImage = new User({
       id: 'ID',
       name: 'Name',
     })
@@ -27,6 +34,19 @@ describe('User', function() {
   describe('name', () => {
     it('should be return initial value', () => {
       assert(user.name === 'Name')
+    })
+  })
+
+  describe('image', () => {
+    context('when defined', () => {
+      it('should be return initial value', () => {
+        assert(user.image === 'Image')
+      })
+    })
+    context('when undefined', () => {
+      it('should be return no image url', () => {
+        assert(userNoImage.image === NO_IMAGE_URL)
+      })
     })
   })
 })


### PR DESCRIPTION
Slack APIからアバター画像(gravatar)のURLがとれるっぽい。
users.listのAPIだと`members[] -> profile -> image_xxx`あたり。

メッセージの横につけたらかっこいいかもだね。
