### PR TITLE
設定ウィンドウをメモリに常駐させないように修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,14 +14,13 @@ if (process.env.NODE_ENV === 'develop') {
 }
 
 app.on('ready', () => {
-  // windows
-  const mainWindow = MainWindow.getInstance()
-  const settingWindow = SettingWindow.getInstance()
+  // window
+  MainWindow.getInstance().show()
 
   // tray
   const tray = new Tray(`${__dirname}/images/icon.png`)
   const menu = Menu.buildFromTemplate([
-    {label: "Setting", click: () => settingWindow.show()},
+    {label: "Setting", click: () => SettingWindow.getInstance().show()},
     {label: "Quit", click: () => app.quit()},
   ])
   tray.setToolTip(app.getName())

--- a/src/reducers/setting.ts
+++ b/src/reducers/setting.ts
@@ -21,13 +21,13 @@ export default function setting(
   case UPDATE_SETTING:
     return action.setting
   case CANCEL_SETTING:
-    GlobalRepository.settingWindow.hide()
+    GlobalRepository.settingWindow.close()
     break
   case SAVE_SETTING:
     localStorage['slackToken'] = state.slackToken
     localStorage['notifyType'] = state.notifyType
     GlobalRepository.mainWindow.reload()
-    GlobalRepository.settingWindow.hide()
+    GlobalRepository.settingWindow.close()
     break
   }
   return state

--- a/src/styles/containers/SettingContainer.styl
+++ b/src/styles/containers/SettingContainer.styl
@@ -3,5 +3,6 @@
   height 100%
   padding 2em 0
   background-color #f5f5f5
+  border 1px solid #ccc
   -webkit-app-region drag
   -webkit-user-select none

--- a/src/windows/MainWindow.ts
+++ b/src/windows/MainWindow.ts
@@ -24,6 +24,7 @@ export default class MainWindow {
       frame: false,
       resizable: false,
       alwaysOnTop: true,
+      show: false,
     })
     this.window.setVisibleOnAllWorkspaces(true)
     this.window.on('closed', () => app.quit())
@@ -39,8 +40,8 @@ export default class MainWindow {
     }
   }
 
-  close() {
-    this.window.close()
+  show() {
+    this.window.show()
   }
 
   reload() {

--- a/src/windows/SettingWindow.ts
+++ b/src/windows/SettingWindow.ts
@@ -27,7 +27,6 @@ export default class SettingWindow {
       show: false,
     })
     this.window.setVisibleOnAllWorkspaces(true)
-    this.window.on('closed', () => app.quit())
     this.window.loadURL(`${BASE_URL}#setting`)
   }
 
@@ -35,9 +34,10 @@ export default class SettingWindow {
     this.window.show()
   }
 
-  hide() {
-    this.window.hide()
-    this.window.reload()
+  close() {
+    SettingWindow.instance = undefined
+    GlobalRepository.settingWindow = undefined
+    this.window.close()
   }
 
   // singleton


### PR DESCRIPTION
#25 対策。
メモリリークではないけど、メモリがもったいないので。
ただし、設定ウィンドウを開くのが若干遅くなる。