### PR TITLE
パスワード系の入力項目をフォーカス時のみ値表示

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -5,11 +5,13 @@ import {Component, PropTypes} from "react"
 interface Props {
   value: string
   placeholder: string
+  hideFirst?: boolean
   onChange?: (text: string)=>void
 }
 
 interface State {
-  text: string
+  text?: string
+  hide?: boolean
 }
 
 export default class TextField extends Component<Props, State> {
@@ -17,18 +19,33 @@ export default class TextField extends Component<Props, State> {
     super()
     this.state = {
       text: props.value || "",
+      hide: props.hideFirst || false,
     }
   }
 
   render() {
     const {placeholder} = this.props
-    const {text} = this.state
+    const {text, hide} = this.state
+    const component = (() => {
+      if (text && hide) {
+        return (
+          <input type="text"
+            placeholder={`${placeholder} (display value on focus)`}
+            onFocus={e => this.showValue()} />
+        )
+      } else {
+        return (
+          <input type="text"
+            value={text}
+            placeholder={placeholder}
+            onChange={e => this.handleChange(e)}
+            onBlur={e => this.hideValue()} />
+        )
+      }
+    })()
     return (
       <span className="TextField">
-        <input type="text"
-          value={text}
-          placeholder={placeholder}
-          onChange={e => this.handleChange(e)} />
+        {component}
       </span>
     )
   }
@@ -39,6 +56,18 @@ export default class TextField extends Component<Props, State> {
     const {onChange} = this.props
     if (onChange) {
       onChange(text)
+    }
+  }
+
+  showValue() {
+    if (this.props.hideFirst) {
+      this.setState({hide: false})
+    }
+  }
+
+  hideValue() {
+    if (this.props.hideFirst) {
+      this.setState({hide: true})
     }
   }
 }

--- a/src/containers/SettingContainer.tsx
+++ b/src/containers/SettingContainer.tsx
@@ -29,6 +29,7 @@ class SettingContainer extends Component<Props, any> {
             <TextField
               placeholder="Slack Token"
               value={setting.slackToken}
+              hideFirst={true}
               onChange={slackToken => this.changeValue({slackToken})} />
           </div>
           <div className="pure-control-group">

--- a/src/windows/SettingWindow.ts
+++ b/src/windows/SettingWindow.ts
@@ -27,6 +27,10 @@ export default class SettingWindow {
     this.window.setVisibleOnAllWorkspaces(true)
     this.window.loadURL(`${BASE_URL}#setting`)
 
+    // only darwin @todo tsd
+    const thisAny = <any>this.window
+    thisAny.setHasShadow(false)
+
     // enable devtools on development
     if (process.env.NODE_ENV === "develop") {
       this.window.webContents.openDevTools()


### PR DESCRIPTION
セキュリティーのため。
とりあえず、対象はSlackTokenのみ。